### PR TITLE
Fix small typos in response.go error messages

### DIFF
--- a/response.go
+++ b/response.go
@@ -64,11 +64,11 @@ func IsValid(x *Response, appSettings *AppSettings, accountSettings *AccountSett
 	}
 
 	if x.Assertion.Subject.SubjectConfirmation.Method != "urn:oasis:names:tc:SAML:2.0:cm:bearer" {
-		return errors.New("asserition method exception")
+		return errors.New("assertion method exception")
 	}
 
 	if x.Assertion.Subject.SubjectConfirmation.SubjectConfirmationData.Recipient != appSettings.AssertionConsumerServiceURL {
-		return errors.New("subject recipient miss match, expected: " + appSettings.AssertionConsumerServiceURL + " not " + x.Destination)
+		return errors.New("subject recipient mismatch, expected: " + appSettings.AssertionConsumerServiceURL + " not " + x.Destination)
 	}
 
 	//CHECK TIMES


### PR DESCRIPTION
s/asserition/assertion/
s/miss match/mismatch/

I did not run any tests for this change, sorry.
